### PR TITLE
feat: Data upserts and deletes

### DIFF
--- a/app/analyzers/rule_analyzer.py
+++ b/app/analyzers/rule_analyzer.py
@@ -6,12 +6,12 @@ from app.analyzers.stage_analyzer import StageAnalyzer
 class ValidationRuleAnalyzer(StageAnalyzer):
     def __init__(self, config, base_url, headers):
         super().__init__(config, base_url, headers)
-
-    async def run_stage(self, stage, session, semaphore):
-        logging.info(f"Running validation rule stage '{stage['name']}'")
-
+        
+    async def data_values_urls_for_orgunits(self,stage,session, semaphore):
+        urls = []
         start_date = self.get_start_date(stage)
         params = stage['params']
+        data_element = params['destination_data_element']
 
         organisation_unit = stage.get('organisation_unit')
         if isinstance(organisation_unit, list):
@@ -19,36 +19,82 @@ class ValidationRuleAnalyzer(StageAnalyzer):
         else:
             ous = await self.get_organisation_units_at_level(params['level'], session, semaphore)
 
-        vrg = params['validation_rule_group']
-        max_results = params.get('max_results', self.config['server'].get('max_results', 500))
-        data_element = params['destination_data_element']
+        params = {
+            'dataElement': data_element,
+            'startDate': start_date.strftime('%Y-%m-%d'),
+            'endDate': datetime.now().strftime('%Y-%m-%d'),
+            'children': 'true'}
+        
+        for ou in ous:
+            params['orgUnit'] = ou
+            query_string = '&'.join(f"{key}={value}" for key, value in params.items())
+            url = f"{self.base_url}/api/dataValueSets.json?{query_string}"
+            urls.append(url)
+        return urls
 
+    async def fetch_existing_datvalues(self,stage, session, semaphore):
+        urls = await self.data_values_urls_for_orgunits(stage, session, semaphore)
         tasks = [
-            self._fetch_validation_rule_analysis_async(
-                session, vrg, ou, start_date, data_element, max_results, semaphore
+              self.fetch_datavalues_async(
+                session, url, semaphore
             )
-            for ou in ous
+            for url in urls
         ]
 
-        results_nested = await asyncio.gather(*tasks)
-        results = []
-        errors = []
+        results = await asyncio.gather(*tasks)
 
-        for result in results_nested:
+        data_values = []
+        for result in results:
             if isinstance(result, Exception):
-                logging.error(f"Validation rule analysis failed: {result}")
-                errors.append(str(result))
-            elif isinstance(result, list):
-                results.extend(result)
+                logging.error(f"Error fetching data values: {result}")
+            elif isinstance(result, dict):
+                data_values.extend(result.get('dataValues', []))
             else:
-                msg = f"Unexpected result in validation rule analysis: {type(result)}"
-                logging.warning(msg)
-                errors.append(msg)
+                logging.warning(f"Unexpected result type: {type(result)} from fetch_existing_datvalues")
+        return data_values
+    
 
-        return {
-            'dataValues': results,
-            'errors': errors
+    def classify_data(self, existing_data_values, calculated_data_values):
+        existing_set = {
+            (dv['dataElement'], dv['orgUnit'], dv['period'], dv.get('categoryOptionCombo', self.default_coc))
+            for dv in existing_data_values
         }
+
+        calculated_set = {
+            (dv['dataElement'], dv['orgUnit'], dv['period'], dv.get('categoryOptionCombo', self.default_coc))
+            for dv in calculated_data_values
+        }
+
+        to_delete = existing_set - calculated_set
+
+        deletions = [
+            {
+                'dataElement': de,
+                'orgUnit': ou,
+                'period': period,
+                'categoryOptionCombo': coc
+            }
+            for de, ou, period, coc in to_delete
+        ]
+
+        upserts = calculated_set - existing_set
+
+        upsert_values = []
+        delete_values = []
+        #Filter the calculated set with the final upserts
+        for upsert in upserts:
+            for dv in calculated_data_values:
+                if (dv['dataElement'], dv['orgUnit'], dv['period'], dv.get('categoryOptionCombo', self.default_coc)) == upsert:
+                    upsert_values.append(dv)
+                    break
+        #Filter the existing set with the final deletions
+        for deletion in to_delete:
+            for dv in existing_data_values:
+                if (dv['dataElement'], dv['orgUnit'], dv['period'], dv.get('categoryOptionCombo', self.default_coc)) == deletion:
+                    delete_values.append(dv)
+                    break
+        return upsert_values, delete_values
+
 
     async def _fetch_validation_rule_analysis_async(self, session, vrg, ou, start_date, data_element, max_results,
                                                     semaphore):
@@ -77,7 +123,6 @@ class ValidationRuleAnalyzer(StageAnalyzer):
             logging.error(f"Error fetching validation rule analysis: {e}")
             return e
 
-        # ✅ Safe-check and normalize
         if not isinstance(response_data, list):
             logging.warning(f"Expected list from DHIS2 validation API but got {type(response_data)}: {response_data}")
             return []
@@ -98,4 +143,52 @@ class ValidationRuleAnalyzer(StageAnalyzer):
             'categoryOptionCombo': self.default_coc,
             'value': count
         } for (ou_id, period_id), count in violations.items()]
+    
+
+    async def run_stage(self, stage, session, semaphore):
+        logging.info(f"Running validation rule stage '{stage['name']}'")
+
+        start_date = self.get_start_date(stage)
+        params = stage['params']
+        vrg = params['validation_rule_group']
+        max_results = params.get('max_results', self.config['server'].get('max_results', 500))
+        data_element = params['destination_data_element']
+
+        organisation_unit = stage.get('organisation_unit')
+        ous = []
+        if isinstance(organisation_unit, list):
+            ous = organisation_unit
+        else:
+            ous = await self.get_organisation_units_at_level(params['level'], session, semaphore)
+
+        tasks = [
+            self._fetch_validation_rule_analysis_async(
+                session, vrg, ou, start_date, data_element, max_results, semaphore
+            )
+            for ou in ous
+        ]
+
+        results_nested = await asyncio.gather(*tasks)
+        results = []
+        errors = []
+
+        for result in results_nested:
+            if isinstance(result, Exception):
+                logging.error(f"Validation rule analysis failed: {result}")
+                errors.append(str(result))
+            elif isinstance(result, list):
+                results.extend(result)
+            else:
+                msg = f"Unexpected result in validation rule analysis: {type(result)}"
+                logging.warning(msg)
+                errors.append(msg)
+
+        existing_data_values = await self.fetch_existing_datvalues(stage, session, semaphore)
+        upserts, deletions = self.classify_data(existing_data_values, results)
+
+        return {
+            'dataValues': upserts,
+            'deletions': deletions,
+            'errors': errors
+        }
 

--- a/app/analyzers/stage_analyzer.py
+++ b/app/analyzers/stage_analyzer.py
@@ -45,3 +45,10 @@ class StageAnalyzer(ABC):
             return f"Invalid duration provided '{unit}'. Must be one of: {', '.join(TimeUnit.list())}"
 
         return None
+
+    async def fetch_datavalues_async(self, session, url, semaphore):
+        async with semaphore:
+            async with session.get(url, headers=self.headers) as response:
+                if response.status != 200:
+                    raise Exception(f"Failed to fetch data values from {url}: HTTP {response.status}")
+                return await response.json()

--- a/app/core/api_utils.py
+++ b/app/core/api_utils.py
@@ -83,11 +83,16 @@ class Dhis2ApiUtils:
                 raise requests.exceptions.RequestException(f"Failed to fetch data value sets: {response.status}")
             return await response.json()
 
-    async def create_and_post_data_value_set(self, data_values, session):
+    async def create_and_post_data_value_set(self, data_values, session, params=None):
         datavalue_set = {
             'dataValues': data_values
         }
         url = f'{self.base_url}/api/dataValueSets'
+        if params:
+            #Any extra params to add to the URL from the params dict
+            query = '&'.join([f"{key}={value}" for key, value in params.items()])
+            url = f'{url}?{query}'
+
         async with session.post(url, json=datavalue_set) as response:
             if response.status != 200:
                 logging.error(f"Failed to post data value set: {response.status}")

--- a/app/core/config_loader.py
+++ b/app/core/config_loader.py
@@ -107,8 +107,6 @@ class ConfigManager:
         if duplicates:
             raise ValueError(f"Duplicate stage names found: {', '.join(duplicates)}")
 
-
-
     def _validate_stage_params(self, stage):
         params = stage['params']
         stage_type = stage['type']

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,6 +18,29 @@ Here is an example of the server configuration:
      max_results: 1000              # caps results per request (500–50000)
 
 
+Maximum concurrent requests
+----------------------------------
+The `max_concurrent_requests` setting controls the number of simultaneous API calls that the DQ Workbench will make to the DHIS2 instance. 
+Increasing this value can speed up processing, but
+it may also lead to rate limiting or timeouts if the DHIS2 server cannot handle the load. 
+A value between 5 and 10 is generally recommended, but you should adjust this based on your server's capabilities and performance.    
+
+
+Maximum results per request
+----------------------------------
+The `max_results` setting determines the maximum number of data quality results which can be returned from the API. In recent versions of 
+DHIS2, you can adjust this value between 500 and 50000. In general, if you are using the DQ Workbench to monitor a large number of validation rules or outliers,
+you will need to increase this value to ensure that all results are returned. However, setting this value too high may lead to performance issues or timeouts, so it is recommended to start with a lower value and increase it as needed.
+Some experimentation may be required to find the optimal value for your specific use case and server configuration. Values of 5000 or 10,000 are often a good starting point.
+
+In order to change  the server configuration, you can make a POST request to the `/api/systemSettings` endpoint with the following JSON payload:
+
+.. code-block:: json
+    {
+    "maxDataQualityResults": 10000
+   }
+
+
 Creating a dedicated user account
 ----------------------------------
 

--- a/docs/slides/index.rst
+++ b/docs/slides/index.rst
@@ -55,6 +55,7 @@ Configuration (YAML)
 Monitoring
 ===========
 
+
 Validation Rules
 -----------------
 - Maps a count of  validation rule violations for selected groups over a time window
@@ -74,18 +75,7 @@ Running an outlier stage
    :alt: Outlier stage run
    :class: r-stretch
 
-Integrity Checks
-----------------
-- Maps the count of integrity violations to a data element
-- Enables tracking of (meta)data integrity over time
-- Support for various period types (Monthly, Weekly, Daily)
 
-
-Create integrity stage
-------------------------
-.. image:: ../_static/screenshots/create_integrity_stage.png
-   :alt: Integrity checks configuration
-   :class: r-stretch
 
 Min-max Generation
 ==================
@@ -129,3 +119,8 @@ Min-max Statistical methods
 - Box-Cox: Uses Box-Cox transformation for normality, then mean ± Threshold*stddev
 - IQR: Q1 - 1.5*IQR to Q3 + 1.5*IQR from the lookback period
 - Constant range: User-defined fixed min and max values
+
+Roadmap??
+===========
+- Zero value analysis
+- Timelieness and completeness


### PR DESCRIPTION
This PR is concerned with providing a means to delete monitoring data when necessary.As an example, a given organisation unit might have a number of validation rule violations, which will result in a non-null, non-zero count for a given monitoring data element. When all validation rule violations are resolved, nothing will be returned by the validation rule API. 

In this PR, we fetch existing data, compare it to what is calculated for a given VR analysis, and produce two datasaets, one for upserts and one for deletes. This of course requires more requests, but is currently the most efficient way to deal with this. 