### PR TITLE
feat: Windows installer (PyInstaller + Inno Setup + waitress)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,39 @@
+# .github/workflows/windows-installer.yml
+name: Build Windows installer
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e .[dev] pyinstaller
+
+      - name: Build with PyInstaller
+        working-directory: installer
+        run: pyinstaller dq_workbench.spec
+
+      - name: Build installer with Inno Setup
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            /DAppVersion=$version `
+            installer\dq_workbench_win.iss
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: installer/Output/dq-workbench-*-windows-setup.exe

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ tests/__pycache__/
 docs/_build/
 docs/**/_build/
 
+.worktrees/

--- a/app/web/app.py
+++ b/app/web/app.py
@@ -1,6 +1,9 @@
 import argparse
 import logging
 import os
+import threading
+import webbrowser
+from waitress import serve
 
 from flask import Flask
 
@@ -171,7 +174,12 @@ def main():
         for rule in app.url_map.iter_rules():
             print(f"  {rule.endpoint}: {rule.rule}")
 
-    app.run(debug=args.debug, use_reloader=False)
+    threading.Timer(1.5, lambda: webbrowser.open("http://127.0.0.1:5000")).start()
+    print("=" * 60)
+    print("DQ Workbench is running at http://127.0.0.1:5000")
+    print("Close this window to stop the server.")
+    print("=" * 60)
+    serve(app, host="127.0.0.1", port=5000)
 
 
 if __name__ == '__main__':

--- a/app/web/app.py
+++ b/app/web/app.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import sys
 import threading
 import webbrowser
 from waitress import serve
@@ -66,7 +67,6 @@ def _resolve_config_path(cli_arg):
     DQ_CONFIG_PATH is a new env var for the desktop use case.
     The existing CONFIG_PATH env var remains Docker/gunicorn-only (read by create_app_from_env).
     """
-    import sys
     from pathlib import Path
     if cli_arg:
         return Path(cli_arg)
@@ -122,7 +122,18 @@ def _bootstrap_config(config_path, base_url, api_token):
 
 
 def create_app(config_path, skip_validation=False):
-    app = Flask(__name__)
+    if getattr(sys, 'frozen', False):
+        # Running as a PyInstaller bundle.
+        # --onedir: resources are next to the executable
+        # --onefile: resources are in sys._MEIPASS (temp dir)
+        bundle_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+        app = Flask(
+            __name__,
+            template_folder=os.path.join(bundle_dir, 'app', 'web', 'templates'),
+            static_folder=os.path.join(bundle_dir, 'app', 'web', 'static'),
+        )
+    else:
+        app = Flask(__name__)
     _configure_secret_key(app)
     _configure_app(app, config_path, skip_validation)
 

--- a/docs/superpowers/plans/2026-03-17-windows-installer.md
+++ b/docs/superpowers/plans/2026-03-17-windows-installer.md
@@ -1,0 +1,621 @@
+# Windows Installer (PyInstaller + Inno Setup) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Package the DQ Workbench web UI as a Windows `.exe` installer so non-technical users can install and run it by double-clicking, with no command-line interaction required.
+
+**Architecture:** PyInstaller `--onedir` bundles the Flask app + all dependencies into a directory; Inno Setup wraps that directory into a standard Windows installer wizard; a GitHub Actions `windows-latest` workflow builds the installer automatically on every version tag. The Flask dev server is replaced with `waitress` (cross-platform WSGI server). The existing zero-config startup feature handles first-run config creation automatically.
+
+**Tech Stack:** Python 3.11, waitress 3.x, PyInstaller 6.x, Inno Setup 6, GitHub Actions
+
+---
+
+## File Structure
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `pyproject.toml` | Modify | Add `waitress` dep; add `sys_platform != 'win32'` marker to `gunicorn` |
+| `app/web/app.py` | Modify | Replace `app.run()` with `waitress.serve()`; add `sys.frozen` path fix in `create_app()` |
+| `installer/main_win.py` | Create | Clean PyInstaller entry point |
+| `installer/dq_workbench.spec` | Create | PyInstaller spec: declares templates/static assets and hidden imports |
+| `installer/dq_workbench_win.iss` | Create | Inno Setup script: installer wizard, shortcuts, uninstaller |
+| `.github/workflows/windows-installer.yml` | Create | CI: builds `.exe` on every `v*` tag and attaches to GitHub Release |
+| `tests/test_web_app_waitress.py` | Create | Tests for waitress integration and PyInstaller path resolution |
+
+---
+
+## Chunk 1: Python Changes
+
+### Task 1: Add waitress dependency
+
+**Files:**
+- Modify: `pyproject.toml:10-22`
+
+- [ ] **Step 1: Update pyproject.toml**
+
+  Replace the `gunicorn` line and add `waitress`:
+
+  ```toml
+  "gunicorn>=23,<25; sys_platform != 'win32'",
+  "waitress>=3.0,<4",
+  ```
+
+  The `sys_platform != 'win32'` marker means gunicorn silently skips installation on Windows (it is Linux/macOS only). `waitress` installs everywhere.
+
+- [ ] **Step 2: Reinstall the package**
+
+  ```bash
+  pip install -e .
+  ```
+
+  Expected: no errors. `waitress` appears in `pip list`.
+
+- [ ] **Step 3: Verify waitress is importable**
+
+  ```bash
+  python -c "from waitress import serve; print('waitress ok')"
+  ```
+
+  Expected: `waitress ok`
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add pyproject.toml
+  git commit -m "feat: add waitress dep; restrict gunicorn to non-Windows"
+  ```
+
+---
+
+### Task 2: Replace app.run() with waitress in main()
+
+**Files:**
+- Modify: `app/web/app.py`
+- Create: `tests/test_web_app_waitress.py`
+
+The current `main()` ends with `app.run(debug=args.debug, use_reloader=False)`. Replace it with `waitress.serve()` and add an auto-open browser call.
+
+Move three imports to module level (required for test mocking):
+
+- [ ] **Step 1: Write the failing test**
+
+  Create `tests/test_web_app_waitress.py`:
+
+  ```python
+  # tests/test_web_app_waitress.py
+  import sys
+  import yaml
+  import pytest
+  from unittest.mock import patch, call
+
+
+  @pytest.fixture
+  def config_file(tmp_path):
+      cfg = tmp_path / "config.yml"
+      cfg.write_text(yaml.dump({
+          'server': {
+              'base_url': 'https://dhis2.example.org',
+              'd2_token': 'fake-token',
+              'logging_level': 'INFO',
+              'max_concurrent_requests': 5,
+              'max_results': 500,
+          },
+          'analyzer_stages': [],
+      }))
+      return str(cfg)
+
+
+  def test_main_serves_via_waitress(config_file, monkeypatch):
+      """main() must use waitress.serve, not app.run()."""
+      monkeypatch.setattr(sys, 'argv', ['prog', '--config', config_file, '--skip-validation'])
+      with patch('app.web.app.serve') as mock_serve, \
+           patch('app.web.app.threading') as mock_threading:
+          from app.web.app import main
+          main()
+      mock_serve.assert_called_once()
+      _, kwargs = mock_serve.call_args
+      assert kwargs['host'] == '127.0.0.1'
+      assert kwargs['port'] == 5000
+
+
+  def test_main_opens_browser(config_file, monkeypatch):
+      """main() must schedule a browser open via threading.Timer."""
+      monkeypatch.setattr(sys, 'argv', ['prog', '--config', config_file, '--skip-validation'])
+      with patch('app.web.app.serve'), \
+           patch('app.web.app.threading') as mock_threading:
+          from app.web.app import main
+          main()
+      mock_threading.Timer.assert_called_once()
+      timer_args = mock_threading.Timer.call_args[0]
+      assert timer_args[0] == 1.5   # delay in seconds
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```bash
+  pytest tests/test_web_app_waitress.py -v
+  ```
+
+  Expected: FAIL — `app.web.app` has no attribute `serve` or `threading`.
+
+- [ ] **Step 3: Update app/web/app.py**
+
+  **Add three imports at the top of the file** (after `import os`, before `from flask import Flask`):
+
+  ```python
+  import threading
+  import webbrowser
+  from waitress import serve
+  ```
+
+  **Replace the last line of `main()`** — change:
+  ```python
+  app.run(debug=args.debug, use_reloader=False)
+  ```
+  to:
+  ```python
+  threading.Timer(1.5, lambda: webbrowser.open("http://127.0.0.1:5000")).start()
+  print("=" * 60)
+  print("DQ Workbench is running at http://127.0.0.1:5000")
+  print("Close this window to stop the server.")
+  print("=" * 60)
+  serve(app, host="127.0.0.1", port=5000)
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+  ```bash
+  pytest tests/test_web_app_waitress.py -v
+  ```
+
+  Expected: PASS (both tests green)
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+  ```bash
+  pytest
+  ```
+
+  Expected: same pass/fail count as before (the known `test_values_boxcox_with_zero` failure is pre-existing and unrelated)
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add app/web/app.py tests/test_web_app_waitress.py
+  git commit -m "feat: serve via waitress with auto-open browser"
+  ```
+
+---
+
+### Task 3: Add PyInstaller path resolution in create_app()
+
+**Files:**
+- Modify: `app/web/app.py:121-130`
+- Modify: `tests/test_web_app_waitress.py` (add one test)
+
+When running as a PyInstaller `--onedir` bundle, `sys.frozen` is set to `True` and Flask cannot find templates/static at their normal package-relative paths. We must point Flask to the correct locations inside the bundle.
+
+**How PyInstaller `--onedir` works:** All files (including templates/static declared in `datas`) are placed next to the executable in the bundle directory. `os.path.dirname(sys.executable)` gives us that directory. If `sys._MEIPASS` is set (some PyInstaller versions also set it for `--onedir`), we prefer it; otherwise fall back to `dirname(sys.executable)`.
+
+- [ ] **Step 1: Write the failing test**
+
+  Append to `tests/test_web_app_waitress.py`:
+
+  ```python
+  def test_create_app_uses_bundle_paths_when_frozen(tmp_path, monkeypatch):
+      """create_app() must use bundle paths for templates/static when sys.frozen is set."""
+      import os
+      cfg = tmp_path / "config.yml"
+      cfg.write_text(yaml.dump({
+          'server': {
+              'base_url': '',
+              'd2_token': '',
+              'logging_level': 'INFO',
+              'max_concurrent_requests': 5,
+              'max_results': 500,
+          },
+          'analyzer_stages': [],
+      }))
+      fake_bundle_dir = str(tmp_path / 'bundle')
+      monkeypatch.setattr(sys, 'frozen', True, raising=False)
+      monkeypatch.setattr(sys, '_MEIPASS', fake_bundle_dir, raising=False)
+
+      from app.web.app import create_app
+      flask_app = create_app(str(cfg), skip_validation=True)
+
+      assert flask_app.template_folder == os.path.join(fake_bundle_dir, 'app', 'web', 'templates')
+      assert flask_app.static_folder == os.path.join(fake_bundle_dir, 'app', 'web', 'static')
+
+
+  def test_create_app_uses_normal_paths_when_not_frozen(tmp_path, monkeypatch):
+      """create_app() must use standard Flask paths when not running as a bundle."""
+      cfg = tmp_path / "config.yml"
+      cfg.write_text(yaml.dump({
+          'server': {
+              'base_url': '',
+              'd2_token': '',
+              'logging_level': 'INFO',
+              'max_concurrent_requests': 5,
+              'max_results': 500,
+          },
+          'analyzer_stages': [],
+      }))
+      # Ensure sys.frozen is NOT set
+      monkeypatch.delattr(sys, 'frozen', raising=False)
+
+      from app.web.app import create_app
+      flask_app = create_app(str(cfg), skip_validation=True)
+
+      # Flask default: template_folder is 'templates' (relative)
+      assert flask_app.template_folder == 'templates'
+  ```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+  ```bash
+  pytest tests/test_web_app_waitress.py::test_create_app_uses_bundle_paths_when_frozen \
+         tests/test_web_app_waitress.py::test_create_app_uses_normal_paths_when_not_frozen -v
+  ```
+
+  Expected: FAIL — `create_app()` does not check `sys.frozen`.
+
+- [ ] **Step 3: Update create_app() in app/web/app.py**
+
+  Replace the current `create_app` opening:
+
+  ```python
+  def create_app(config_path, skip_validation=False):
+      app = Flask(__name__)
+  ```
+
+  with:
+
+  ```python
+  def create_app(config_path, skip_validation=False):
+      if getattr(sys, 'frozen', False):
+          # Running as a PyInstaller bundle.
+          # --onedir: resources are next to the executable
+          # --onefile: resources are in sys._MEIPASS (temp dir)
+          bundle_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+          app = Flask(
+              __name__,
+              template_folder=os.path.join(bundle_dir, 'app', 'web', 'templates'),
+              static_folder=os.path.join(bundle_dir, 'app', 'web', 'static'),
+          )
+      else:
+          app = Flask(__name__)
+  ```
+
+  Note: `sys` is now imported at module level (added in Task 2). `os` was already imported at the top of the file.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+  ```bash
+  pytest tests/test_web_app_waitress.py -v
+  ```
+
+  Expected: all 4 tests pass
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+  ```bash
+  pytest
+  ```
+
+  Expected: same pass/fail count as before
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add app/web/app.py tests/test_web_app_waitress.py
+  git commit -m "feat: resolve template/static paths from PyInstaller bundle dir"
+  ```
+
+---
+
+## Chunk 2: Installer Files
+
+### Task 4: Create PyInstaller entry point and spec file
+
+**Files:**
+- Create: `installer/main_win.py`
+- Create: `installer/dq_workbench.spec`
+
+PyInstaller requires a top-level script as its entry point. We use a thin shim so `app/web/app.py` stays clean.
+
+- [ ] **Step 1: Create installer/ directory and entry point**
+
+  ```bash
+  mkdir -p installer
+  ```
+
+  Create `installer/main_win.py`:
+
+  ```python
+  # installer/main_win.py
+  # PyInstaller entry point for the Windows desktop app.
+  from app.web.app import main
+
+  if __name__ == '__main__':
+      main()
+  ```
+
+- [ ] **Step 2: Verify the entry point works**
+
+  From the project root:
+
+  ```bash
+  python installer/main_win.py --help
+  ```
+
+  Expected: prints the argparse help message and exits (no errors).
+
+- [ ] **Step 3: Create installer/dq_workbench.spec**
+
+  ```python
+  # installer/dq_workbench.spec
+  # -*- mode: python ; coding: utf-8 -*-
+
+  block_cipher = None
+
+  a = Analysis(
+      ['main_win.py'],
+      pathex=['..'],          # project root — so 'app.web.app' resolves correctly
+      binaries=[],
+      datas=[
+          ('../app/web/templates', 'app/web/templates'),
+          ('../app/web/static',    'app/web/static'),
+      ],
+      hiddenimports=[
+          'waitress',
+          'waitress.utilities',
+          'flask_wtf',
+          'pkg_resources',
+          'pkg_resources.extern',
+      ],
+      hookspath=[],
+      hooksconfig={},
+      runtime_hooks=[],
+      excludes=['gunicorn'],  # gunicorn is Linux-only; exclude from the Windows bundle
+      win_no_prefer_redirects=False,
+      win_private_assemblies=False,
+      cipher=block_cipher,
+      noarchive=False,
+  )
+
+  pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+  exe = EXE(
+      pyz,
+      a.scripts,
+      [],
+      exclude_binaries=True,
+      name='dq-workbench',
+      debug=False,
+      bootloader_ignore_signals=False,
+      strip=False,
+      upx=True,
+      console=True,           # Keep console window — closing it stops the server
+      disable_windowed_traceback=False,
+      argv_emulation=False,
+      target_arch=None,
+      codesign_identity=None,
+      entitlements_file=None,
+  )
+
+  coll = COLLECT(
+      exe,
+      a.binaries,
+      a.zipfiles,
+      a.datas,
+      strip=False,
+      upx=True,
+      upx_exclude=[],
+      name='dq-workbench',
+  )
+  ```
+
+- [ ] **Step 4: Verify the spec file is valid Python**
+
+  ```bash
+  python -c "
+  import ast, sys
+  with open('installer/dq_workbench.spec') as f:
+      src = f.read()
+  ast.parse(src)
+  print('spec syntax ok')
+  "
+  ```
+
+  Expected: `spec syntax ok`
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add installer/main_win.py installer/dq_workbench.spec
+  git commit -m "feat: add PyInstaller entry point and spec file"
+  ```
+
+---
+
+### Task 5: Create Inno Setup script
+
+**Files:**
+- Create: `installer/dq_workbench_win.iss`
+
+Inno Setup reads this script to produce the `.exe` installer. `AppVersion` is passed at build time with `/DAppVersion=X.Y.Z`.
+
+- [ ] **Step 1: Create installer/dq_workbench_win.iss**
+
+  ```ini
+  ; installer/dq_workbench_win.iss
+  ; Inno Setup 6 script for DQ Workbench
+  ; Build with: ISCC.exe /DAppVersion=0.9.4 dq_workbench_win.iss
+
+  [Setup]
+  AppName=DQ Workbench
+  AppVersion={#AppVersion}
+  AppPublisher=DHIS2
+  DefaultDirName={autopf}\DQ Workbench
+  DefaultGroupName=DQ Workbench
+  OutputBaseFilename=dq-workbench-{#AppVersion}-windows-setup
+  OutputDir=Output
+  Compression=lzma
+  SolidCompression=yes
+  ; Installer requires Windows 10 or later
+  MinVersion=10.0
+
+  [Languages]
+  Name: "english"; MessagesFile: "compiler:Default.isl"
+
+  [Files]
+  ; Bundle all files from the PyInstaller --onedir output
+  Source: "..\dist\dq-workbench\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+
+  [Icons]
+  ; Start Menu shortcuts
+  Name: "{group}\DQ Workbench";  Filename: "{app}\dq-workbench.exe"
+  Name: "{group}\Uninstall DQ Workbench"; Filename: "{uninstallexe}"
+  ; Optional desktop shortcut (user opts in via checkbox during install)
+  Name: "{commondesktop}\DQ Workbench"; Filename: "{app}\dq-workbench.exe"; Tasks: desktopicon
+
+  [Tasks]
+  Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"; Flags: unchecked
+
+  [Run]
+  ; Offer to launch the app at the end of the install wizard
+  Filename: "{app}\dq-workbench.exe"; Description: "Launch DQ Workbench now"; Flags: postinstall nowait skipifsilent
+  ```
+
+- [ ] **Step 2: Verify the .iss file is well-formed**
+
+  The ISS format cannot be validated without Inno Setup itself (Windows-only). Instead, verify it is valid UTF-8 text with expected section headers:
+
+  ```bash
+  python -c "
+  import re
+  with open('installer/dq_workbench_win.iss', encoding='utf-8') as f:
+      content = f.read()
+  required = ['[Setup]', '[Files]', '[Icons]', '[Tasks]', '[Run]']
+  for section in required:
+      assert section in content, f'Missing section: {section}'
+  print('ISS structure ok')
+  "
+  ```
+
+  Expected: `ISS structure ok`
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add installer/dq_workbench_win.iss
+  git commit -m "feat: add Inno Setup installer script"
+  ```
+
+---
+
+### Task 6: Create GitHub Actions workflow
+
+**Files:**
+- Create: `.github/workflows/windows-installer.yml`
+
+Triggered on every `v*` tag push (same pattern as the existing `docker-publish.yml`). Runs on `windows-latest`, which has Inno Setup 6 pre-installed.
+
+- [ ] **Step 1: Create .github/workflows/windows-installer.yml**
+
+  ```yaml
+  # .github/workflows/windows-installer.yml
+  name: Build Windows installer
+
+  on:
+    push:
+      tags:
+        - 'v*'
+
+  jobs:
+    build:
+      runs-on: windows-latest
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: '3.11'
+
+        - name: Install dependencies
+          run: pip install -e .[dev] pyinstaller
+
+        - name: Build with PyInstaller
+          working-directory: installer
+          run: pyinstaller dq_workbench.spec
+
+        - name: Build installer with Inno Setup
+          run: |
+            $version = "${{ github.ref_name }}".TrimStart("v")
+            & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+              /DAppVersion=$version `
+              installer\dq_workbench_win.iss
+
+        - name: Upload to GitHub Release
+          uses: softprops/action-gh-release@v2
+          with:
+            files: installer/Output/dq-workbench-*-windows-setup.exe
+  ```
+
+- [ ] **Step 2: Verify the YAML is valid**
+
+  ```bash
+  python -c "
+  import yaml
+  with open('.github/workflows/windows-installer.yml') as f:
+      data = yaml.safe_load(f)
+  assert data['on']['push']['tags'] == ['v*']
+  assert data['jobs']['build']['runs-on'] == 'windows-latest'
+  print('workflow YAML ok')
+  "
+  ```
+
+  Expected: `workflow YAML ok`
+
+- [ ] **Step 3: Run the full test suite one final time**
+
+  ```bash
+  pytest
+  ```
+
+  Expected: same pass/fail count as before (pre-existing `test_values_boxcox_with_zero` failure is unrelated)
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .github/workflows/windows-installer.yml
+  git commit -m "feat: add GitHub Actions workflow to build Windows installer"
+  ```
+
+---
+
+## Local Build Verification (Manual, Windows only)
+
+After the above tasks are complete, verify the full installer locally on a Windows machine or GitHub Actions:
+
+```powershell
+# From the project root (Windows PowerShell)
+pip install -e .[dev] pyinstaller
+cd installer
+pyinstaller dq_workbench.spec
+cd ..
+& "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=0.9.4 installer\dq_workbench_win.iss
+# Output: installer\Output\dq-workbench-0.9.4-windows-setup.exe
+```
+
+Run the installer and verify:
+1. Wizard completes without error
+2. Start Menu shortcut appears
+3. Double-clicking the shortcut opens a console window
+4. Browser opens to `http://127.0.0.1:5000`
+5. First-run redirects to the server config page
+6. Config created at `C:\Users\<name>\Documents\DQ Workbench\config.yml`
+7. Closing the console window stops the server

--- a/docs/superpowers/specs/2026-03-17-windows-installer-design.md
+++ b/docs/superpowers/specs/2026-03-17-windows-installer-design.md
@@ -1,0 +1,205 @@
+
+# Design: Windows Installer (PyInstaller + Inno Setup)
+
+**Date:** 2026-03-17
+**Status:** Approved
+
+## Overview
+
+Package the DQ Workbench web UI as a standard Windows installer (`.exe`) for non-technical users who are responsible for creating the DHIS2 configuration file and handing it to a sysadmin. The installer must work with no command-line interaction: double-click to install, double-click the shortcut to run.
+
+The zero-config startup feature (already implemented) is a prerequisite — it handles first-run config creation and redirects the user to the server setup page automatically.
+
+## Approach
+
+PyInstaller `--onedir` bundles the Flask app and all dependencies into a directory. Inno Setup wraps that directory into a standard Windows installer wizard. GitHub Actions builds the installer automatically on every version tag using a `windows-latest` runner.
+
+**Not included in scope:**
+- Code signing (trusted user base; SmartScreen "More info → Run anyway" is acceptable)
+- Auto-update (users download and re-run the installer for new versions)
+- System tray icon (console window is sufficient; closing it stops the server)
+
+## Runtime User Experience
+
+1. User downloads `dq-workbench-X.Y.Z-windows-setup.exe` from GitHub Releases
+2. Runs the installer wizard (Next → Next → Install); SmartScreen warns — user clicks "More info → Run anyway"
+3. Double-clicks the Start Menu or desktop shortcut
+4. A console window opens; `waitress` starts serving on `http://127.0.0.1:5000`; browser opens automatically
+5. First run: redirected to the server config page to enter DHIS2 credentials; config created at `C:\Users\<name>\Documents\DQ Workbench\config.yml`
+6. Subsequent runs: dashboard loads directly
+7. User closes the console window to stop the server
+
+## Python Changes
+
+### `pyproject.toml`
+
+Add `waitress` as a runtime dependency. Add a platform marker to `gunicorn` so it is not installed on Windows (gunicorn is Linux/macOS only):
+
+```toml
+"gunicorn>=23,<25; sys_platform != 'win32'",
+"waitress>=3.0,<4",
+```
+
+### `app/web/app.py`
+
+**Replace `app.run()` with waitress in `main()`:**
+
+```python
+import threading
+import webbrowser
+from waitress import serve
+
+# Open browser after waitress has had time to bind the port
+threading.Timer(1.5, lambda: webbrowser.open("http://127.0.0.1:5000")).start()
+
+print("=" * 60)
+print("DQ Workbench is running at http://127.0.0.1:5000")
+print("Close this window to stop the server.")
+print("=" * 60)
+serve(app, host="127.0.0.1", port=5000)
+```
+
+`webbrowser.open` is cross-platform; this path is used on Linux too (replacing Flask's dev server, which is equivalent from the user's perspective). The `--debug` flag prints extra info but still uses waitress.
+
+**Add `sys._MEIPASS` path resolution in `create_app()`:**
+
+When running as a PyInstaller bundle, Flask cannot find templates and static files at their normal paths. Resolve them via `sys._MEIPASS` (the temp directory PyInstaller extracts to):
+
+```python
+import sys
+import os
+
+base = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
+app = Flask(
+    __name__,
+    template_folder=os.path.join(base, 'app', 'web', 'templates'),
+    static_folder=os.path.join(base, 'app', 'web', 'static'),
+)
+```
+
+When not running as a bundle, `sys._MEIPASS` does not exist and `getattr` falls back to the normal package directory — so development and Docker are unaffected.
+
+## New Files
+
+### `installer/main_win.py`
+
+A clean PyInstaller entry point that calls `main()`:
+
+```python
+from app.web.app import main
+
+if __name__ == '__main__':
+    main()
+```
+
+PyInstaller requires a single top-level script as its entry point. Using a separate file avoids polluting `app/web/app.py` with PyInstaller-specific concerns.
+
+### `installer/dq_workbench.spec`
+
+PyInstaller spec file declaring all assets and hidden imports:
+
+```python
+a = Analysis(
+    ['main_win.py'],
+    pathex=['..'],
+    hiddenimports=[
+        'waitress',
+        'flask_wtf',
+        'pkg_resources',
+    ],
+    datas=[
+        ('../app/web/templates', 'app/web/templates'),
+        ('../app/web/static',    'app/web/static'),
+    ],
+)
+pyz = PYZ(a.pure)
+exe = EXE(pyz, a.scripts, name='dq-workbench', console=True)
+coll = COLLECT(exe, a.binaries, a.zipfiles, a.datas, name='dq-workbench')
+```
+
+`console=True` keeps the terminal window visible. `datas` maps templates and static files into the bundle at paths matching what `sys._MEIPASS` resolution expects. Hidden imports cover dynamically-loaded modules that PyInstaller's static analysis misses.
+
+### `installer/dq_workbench_win.iss`
+
+Inno Setup script:
+
+```ini
+[Setup]
+AppName=DQ Workbench
+AppVersion={#AppVersion}
+DefaultDirName={autopf}\DQ Workbench
+DefaultGroupName=DQ Workbench
+OutputBaseFilename=dq-workbench-{#AppVersion}-windows-setup
+OutputDir=Output
+Compression=lzma
+SolidCompression=yes
+
+[Files]
+Source: "..\dist\dq-workbench\*"; DestDir: "{app}"; Flags: recursesubdirs
+
+[Icons]
+Name: "{group}\DQ Workbench";        Filename: "{app}\dq-workbench.exe"
+Name: "{group}\Uninstall";           Filename: "{uninstallexe}"
+Name: "{commondesktop}\DQ Workbench"; Filename: "{app}\dq-workbench.exe"; Tasks: desktopicon
+
+[Tasks]
+Name: desktopicon; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"
+
+[Run]
+Filename: "{app}\dq-workbench.exe"; Description: "Launch DQ Workbench"; Flags: postinstall nowait skipifsilent
+```
+
+`AppVersion` is passed at build time via `/DAppVersion=X.Y.Z`. Output: `installer/Output/dq-workbench-X.Y.Z-windows-setup.exe`.
+
+### `.github/workflows/windows-installer.yml`
+
+Triggered on every `v*` tag push, in parallel with the existing Docker workflow:
+
+```yaml
+name: Build Windows installer
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e .[dev] pyinstaller
+
+      - name: Build with PyInstaller
+        working-directory: installer
+        run: pyinstaller dq_workbench.spec
+
+      - name: Build installer with Inno Setup
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            /DAppVersion=$version `
+            installer\dq_workbench_win.iss
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: installer/Output/dq-workbench-*-windows-setup.exe
+```
+
+`windows-latest` runners have Inno Setup 6 pre-installed. The version is extracted from the git tag (`v0.9.4` → `0.9.4`). The `.exe` is attached to the GitHub Release alongside the Docker image.
+
+## What Is Not Changing
+
+- `create_app_from_env()` and the Docker/gunicorn production path — untouched
+- `CONFIG_PATH` environment variable (Docker-only) — unchanged
+- Linux/macOS command-line usage — waitress is cross-platform; behaviour is identical to today
+- The `--config`, `--skip-validation`, `--debug` flags — unchanged
+- Zero-config startup logic — already implemented; config path on Windows is already `~/Documents/DQ Workbench/config.yml`

--- a/docs/superpowers/specs/2026-03-17-windows-installer-design.md
+++ b/docs/superpowers/specs/2026-03-17-windows-installer-design.md
@@ -196,6 +196,10 @@ jobs:
 
 `windows-latest` runners have Inno Setup 6 pre-installed. The version is extracted from the git tag (`v0.9.4` → `0.9.4`). The `.exe` is attached to the GitHub Release alongside the Docker image.
 
+## Limitations
+
+**Single config file only.** The Windows installer is designed for one config file at a time, stored at the platform default path (`C:\Users\<name>\Documents\DQ Workbench\config.yml`). There is no UI for switching between multiple configs. Technical users who need multiple configs can use `DQ_CONFIG_PATH` or the `--config` flag from the command line, but this is not a supported workflow for the installer target audience.
+
 ## What Is Not Changing
 
 - `create_app_from_env()` and the Docker/gunicorn production path — untouched

--- a/installer/dq_workbench.spec
+++ b/installer/dq_workbench.spec
@@ -3,21 +3,18 @@
 
 block_cipher = None
 
+from PyInstaller.utils.hooks import collect_all
+waitress_datas, waitress_binaries, waitress_hiddenimports = collect_all('waitress')
+
 a = Analysis(
     ['main_win.py'],
     pathex=['..'],          # project root — so 'app.web.app' resolves correctly
-    binaries=[],
+    binaries=waitress_binaries,
     datas=[
         ('../app/web/templates', 'app/web/templates'),
         ('../app/web/static',    'app/web/static'),
-    ],
-    hiddenimports=[
-        'waitress',
-        'waitress.utilities',
-        'flask_wtf',
-        'pkg_resources',
-        'pkg_resources.extern',
-    ],
+    ] + waitress_datas,
+    hiddenimports=['flask_wtf', 'pkg_resources', 'pkg_resources.extern'] + waitress_hiddenimports,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/installer/dq_workbench.spec
+++ b/installer/dq_workbench.spec
@@ -1,0 +1,60 @@
+# installer/dq_workbench.spec
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['main_win.py'],
+    pathex=['..'],          # project root — so 'app.web.app' resolves correctly
+    binaries=[],
+    datas=[
+        ('../app/web/templates', 'app/web/templates'),
+        ('../app/web/static',    'app/web/static'),
+    ],
+    hiddenimports=[
+        'waitress',
+        'waitress.utilities',
+        'flask_wtf',
+        'pkg_resources',
+        'pkg_resources.extern',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=['gunicorn'],  # gunicorn is Linux-only; exclude from the Windows bundle
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='dq-workbench',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,           # Keep console window — closing it stops the server
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='dq-workbench',
+)

--- a/installer/dq_workbench_win.iss
+++ b/installer/dq_workbench_win.iss
@@ -1,0 +1,37 @@
+; installer/dq_workbench_win.iss
+; Inno Setup 6 script for DQ Workbench
+; Build with: ISCC.exe /DAppVersion=0.9.4 dq_workbench_win.iss
+
+[Setup]
+AppName=DQ Workbench
+AppVersion={#AppVersion}
+AppPublisher=DHIS2
+DefaultDirName={autopf}\DQ Workbench
+DefaultGroupName=DQ Workbench
+OutputBaseFilename=dq-workbench-{#AppVersion}-windows-setup
+OutputDir=Output
+Compression=lzma
+SolidCompression=yes
+; Installer requires Windows 10 or later
+MinVersion=10.0
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+; Bundle all files from the PyInstaller --onedir output
+Source: "..\dist\dq-workbench\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+
+[Icons]
+; Start Menu shortcuts
+Name: "{group}\DQ Workbench";  Filename: "{app}\dq-workbench.exe"
+Name: "{group}\Uninstall DQ Workbench"; Filename: "{uninstallexe}"
+; Optional desktop shortcut (user opts in via checkbox during install)
+Name: "{commondesktop}\DQ Workbench"; Filename: "{app}\dq-workbench.exe"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"; Flags: unchecked
+
+[Run]
+; Offer to launch the app at the end of the install wizard
+Filename: "{app}\dq-workbench.exe"; Description: "Launch DQ Workbench now"; Flags: postinstall nowait skipifsilent

--- a/installer/dq_workbench_win.iss
+++ b/installer/dq_workbench_win.iss
@@ -20,7 +20,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
 ; Bundle all files from the PyInstaller --onedir output
-Source: "..\dist\dq-workbench\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+Source: "dist\dq-workbench\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
 
 [Icons]
 ; Start Menu shortcuts

--- a/installer/main_win.py
+++ b/installer/main_win.py
@@ -1,0 +1,6 @@
+# installer/main_win.py
+# PyInstaller entry point for the Windows desktop app.
+from app.web.app import main
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
   "python-dateutil>=2.9,<3.0",
   "PyYAML>=6,<7",
   "requests>=2.32,<3",
-  "gunicorn>=23,<25",
+  "gunicorn>=23,<25; sys_platform != 'win32'",
+  "waitress>=3.0,<4",
   # Runtime scientific stack
   "numpy>=1.26,<2.0",     # has wheels for py3.10–3.12+
   "scipy>=1.12,<1.16",    # avoids the nonexistent 1.16.1 pin

--- a/tests/test_web_app_waitress.py
+++ b/tests/test_web_app_waitress.py
@@ -1,0 +1,46 @@
+# tests/test_web_app_waitress.py
+import sys
+import yaml
+import pytest
+from unittest.mock import patch, call
+
+
+@pytest.fixture
+def config_file(tmp_path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.dump({
+        'server': {
+            'base_url': 'https://dhis2.example.org',
+            'd2_token': 'fake-token',
+            'logging_level': 'INFO',
+            'max_concurrent_requests': 5,
+            'max_results': 500,
+        },
+        'analyzer_stages': [],
+    }))
+    return str(cfg)
+
+
+def test_main_serves_via_waitress(config_file, monkeypatch):
+    """main() must use waitress.serve, not app.run()."""
+    monkeypatch.setattr(sys, 'argv', ['prog', '--config', config_file, '--skip-validation'])
+    with patch('app.web.app.serve') as mock_serve, \
+         patch('app.web.app.threading') as mock_threading:
+        from app.web.app import main
+        main()
+    mock_serve.assert_called_once()
+    _, kwargs = mock_serve.call_args
+    assert kwargs['host'] == '127.0.0.1'
+    assert kwargs['port'] == 5000
+
+
+def test_main_opens_browser(config_file, monkeypatch):
+    """main() must schedule a browser open via threading.Timer."""
+    monkeypatch.setattr(sys, 'argv', ['prog', '--config', config_file, '--skip-validation'])
+    with patch('app.web.app.serve'), \
+         patch('app.web.app.threading') as mock_threading:
+        from app.web.app import main
+        main()
+    mock_threading.Timer.assert_called_once()
+    timer_args = mock_threading.Timer.call_args[0]
+    assert timer_args[0] == 1.5   # delay in seconds

--- a/tests/test_web_app_waitress.py
+++ b/tests/test_web_app_waitress.py
@@ -44,3 +44,50 @@ def test_main_opens_browser(config_file, monkeypatch):
     mock_threading.Timer.assert_called_once()
     timer_args = mock_threading.Timer.call_args[0]
     assert timer_args[0] == 1.5   # delay in seconds
+
+
+def test_create_app_uses_bundle_paths_when_frozen(tmp_path, monkeypatch):
+    """create_app() must use bundle paths for templates/static when sys.frozen is set."""
+    import os
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.dump({
+        'server': {
+            'base_url': '',
+            'd2_token': '',
+            'logging_level': 'INFO',
+            'max_concurrent_requests': 5,
+            'max_results': 500,
+        },
+        'analyzer_stages': [],
+    }))
+    fake_bundle_dir = str(tmp_path / 'bundle')
+    monkeypatch.setattr(sys, 'frozen', True, raising=False)
+    monkeypatch.setattr(sys, '_MEIPASS', fake_bundle_dir, raising=False)
+
+    from app.web.app import create_app
+    flask_app = create_app(str(cfg), skip_validation=True)
+
+    assert flask_app.template_folder == os.path.join(fake_bundle_dir, 'app', 'web', 'templates')
+    assert flask_app.static_folder == os.path.join(fake_bundle_dir, 'app', 'web', 'static')
+
+
+def test_create_app_uses_normal_paths_when_not_frozen(tmp_path, monkeypatch):
+    """create_app() must use standard Flask paths when not running as a bundle."""
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.dump({
+        'server': {
+            'base_url': '',
+            'd2_token': '',
+            'logging_level': 'INFO',
+            'max_concurrent_requests': 5,
+            'max_results': 500,
+        },
+        'analyzer_stages': [],
+    }))
+    monkeypatch.delattr(sys, 'frozen', raising=False)
+
+    from app.web.app import create_app
+    flask_app = create_app(str(cfg), skip_validation=True)
+
+    # Flask default: template_folder is 'templates' (relative)
+    assert flask_app.template_folder == 'templates'

--- a/tests/test_web_app_waitress.py
+++ b/tests/test_web_app_waitress.py
@@ -25,7 +25,7 @@ def test_main_serves_via_waitress(config_file, monkeypatch):
     """main() must use waitress.serve, not app.run()."""
     monkeypatch.setattr(sys, 'argv', ['prog', '--config', config_file, '--skip-validation'])
     with patch('app.web.app.serve') as mock_serve, \
-         patch('app.web.app.threading') as mock_threading:
+         patch('app.web.app.threading'):
         from app.web.app import main
         main()
     mock_serve.assert_called_once()
@@ -43,7 +43,7 @@ def test_main_opens_browser(config_file, monkeypatch):
         main()
     mock_threading.Timer.assert_called_once()
     timer_args = mock_threading.Timer.call_args[0]
-    assert timer_args[0] == 1.5   # delay in seconds
+    assert isinstance(timer_args[0], (int, float)) and timer_args[0] > 0  # positive delay in seconds
 
 
 def test_create_app_uses_bundle_paths_when_frozen(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Replaces `app.run()` with `waitress.serve()` in `main()` — cross-platform WSGI server with auto-open browser on launch; `gunicorn` restricted to non-Windows via platform marker
- Adds `sys.frozen` detection in `create_app()` so Flask resolves templates/static from the PyInstaller bundle directory
- Adds `installer/` directory: `main_win.py` entry point, `dq_workbench.spec` (PyInstaller --onedir with `collect_all('waitress')`), `dq_workbench_win.iss` (Inno Setup 6 script with Start Menu + optional desktop shortcut + post-install launch)
- Adds `.github/workflows/windows-installer.yml` — builds `dq-workbench-X.Y.Z-windows-setup.exe` on every `v*` tag and attaches it to the GitHub Release

## Test Plan
- [ ] 30 unit tests pass (`pytest`)
- [ ] Push a `v*` tag and verify the `windows-installer` workflow completes successfully on GitHub Actions
- [ ] Download the produced `.exe`, run it on Windows, verify: installer wizard completes, Start Menu shortcut appears, double-click opens console + browser at `http://127.0.0.1:5000`, first run redirects to server config page, config created at `Documents\DQ Workbench\config.yml`, closing console stops the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)