### PR TITLE
feat: display config file path on server configuration page

### DIFF
--- a/app/web/routes/edit_server.py
+++ b/app/web/routes/edit_server.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import current_app, request, render_template, redirect, url_for, flash
 
 from app.core.config_loader import ConfigManager
@@ -7,6 +9,7 @@ from app.web.utils.config_helpers import save_config
 @api_bp.route('/edit-server', methods=['GET', 'POST'], endpoint='edit_server')
 def edit_server():
     config_path = current_app.config['CONFIG_PATH']
+    abs_config_path = os.path.abspath(config_path)
     config = ConfigManager(config_path, config=None, validate_structure=False,
                            validate_runtime=False).config
 
@@ -45,7 +48,9 @@ def edit_server():
             return redirect(url_for('ui.index'))
 
         # Return form with the values user submitted
-        return render_template("edit_server.html", server=config['server'])
+        return render_template("edit_server.html", server=config['server'],
+                               config_path=abs_config_path)
 
     # GET request
-    return render_template("edit_server.html", server=config['server'])
+    return render_template("edit_server.html", server=config['server'],
+                           config_path=abs_config_path)

--- a/app/web/templates/edit_server.html
+++ b/app/web/templates/edit_server.html
@@ -10,14 +10,21 @@
     <button
       class="btn btn-sm btn-outline-secondary"
       type="button"
+      aria-label="Copy config file path to clipboard"
       onclick="
-        navigator.clipboard.writeText(document.getElementById('config-path-value').innerText)
-          .then(function() {
-            var btn = event.currentTarget;
+        var path = document.getElementById('config-path-value').innerText;
+        var btn = event.currentTarget;
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(path).then(function() {
             var orig = btn.innerText;
             btn.innerText = 'Copied!';
             setTimeout(function() { btn.innerText = orig; }, 1500);
+          }).catch(function() {
+            window.prompt('Copy this path:', path);
           });
+        } else {
+          window.prompt('Copy this path:', path);
+        }
       "
     >Copy path</button>
   </div>

--- a/app/web/templates/edit_server.html
+++ b/app/web/templates/edit_server.html
@@ -2,6 +2,25 @@
 
 {% block content %}
 {% include "partials/_flashes.html" %}
+  <div class="alert alert-info d-flex align-items-center gap-2 mb-4" role="alert">
+    <div class="flex-grow-1">
+      <strong>Config file location:</strong>
+      <code id="config-path-value">{{ config_path }}</code>
+    </div>
+    <button
+      class="btn btn-sm btn-outline-secondary"
+      type="button"
+      onclick="
+        navigator.clipboard.writeText(document.getElementById('config-path-value').innerText)
+          .then(function() {
+            var btn = event.currentTarget;
+            var orig = btn.innerText;
+            btn.innerText = 'Copied!';
+            setTimeout(function() { btn.innerText = orig; }, 1500);
+          });
+      "
+    >Copy path</button>
+  </div>
   <h1>Edit Server Configuration</h1>
 
   <form method="post">

--- a/tests/test_web_index.py
+++ b/tests/test_web_index.py
@@ -1,6 +1,9 @@
 # tests/test_web_index.py
+import os
+
 import pytest
 import yaml
+
 from app.web.app import create_app
 
 
@@ -100,6 +103,5 @@ def test_onboarding_post_flow(client_blank):
 
 def test_edit_server_shows_config_path(client_blank, blank_config):
     """GET /api/edit-server must display the absolute config file path."""
-    import os
     response = client_blank.get('/api/edit-server')
     assert os.path.abspath(blank_config).encode() in response.data

--- a/tests/test_web_index.py
+++ b/tests/test_web_index.py
@@ -96,3 +96,10 @@ def test_onboarding_post_flow(client_blank):
     # After saving credentials, visiting / should render the dashboard (not redirect again)
     index_response = client_blank.get('/', follow_redirects=False)
     assert index_response.status_code == 200
+
+
+def test_edit_server_shows_config_path(client_blank, blank_config):
+    """GET /api/edit-server must display the absolute config file path."""
+    import os
+    response = client_blank.get('/api/edit-server')
+    assert os.path.abspath(blank_config).encode() in response.data


### PR DESCRIPTION
## Summary

- Displays the absolute config file path prominently on the Edit Server Configuration page inside an info banner
- Adds a copy-to-clipboard button with a fallback to `window.prompt` for HTTP (non-HTTPS) contexts such as LAN deployments
- No download endpoint — avoids exposing the cleartext API token

## Test Plan

- [ ] Navigate to Edit Server Configuration — confirm blue info banner shows the full absolute path above the form heading
- [ ] Click "Copy path" over HTTPS/localhost — confirm path is copied and button briefly shows "Copied!"
- [ ] Click "Copy path" over plain HTTP — confirm `window.prompt` dialog appears with the path pre-filled
- [ ] Verify all 6 tests in `tests/test_web_index.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)