### PR TITLE
feat: show one-time flash notification when newer version is available

### DIFF
--- a/app/web/app.py
+++ b/app/web/app.py
@@ -7,6 +7,7 @@ import webbrowser
 from waitress import serve
 
 from flask import Flask, flash
+from markupsafe import Markup
 
 from app.core.config_loader import ConfigManager
 from .routes import register_routes
@@ -145,8 +146,6 @@ def create_app(config_path, skip_validation=False):
     _configure_logging(app)
 
     register_routes(app)
-
-    from markupsafe import Markup
 
     @app.before_request
     def _notify_if_update_available():

--- a/app/web/app.py
+++ b/app/web/app.py
@@ -6,10 +6,13 @@ import threading
 import webbrowser
 from waitress import serve
 
-from flask import Flask
+from flask import Flask, flash
 
 from app.core.config_loader import ConfigManager
 from .routes import register_routes
+
+
+_available_update: str | None = None  # set by _check_for_updates(); read once by before_request hook
 
 
 def _configure_secret_key(app):
@@ -142,6 +145,23 @@ def create_app(config_path, skip_validation=False):
     _configure_logging(app)
 
     register_routes(app)
+
+    from markupsafe import Markup
+
+    @app.before_request
+    def _notify_if_update_available():
+        global _available_update
+        if _available_update:
+            flash(
+                Markup(
+                    f"A newer version (v{_available_update}) is available. "
+                    '<a href="https://github.com/dhis2/tool-dq-workbench/releases" '
+                    'class="alert-link" target="_blank" rel="noopener">Download it here.</a>'
+                ),
+                'info',
+            )
+            _available_update = None
+
     return app
 
 
@@ -184,6 +204,8 @@ def _check_for_updates():
                 except ValueError:
                     return (0,)
             if _parse(latest_tag) > _parse(current):
+                global _available_update
+                _available_update = latest_tag
                 logging.warning(
                     f"A newer version (v{latest_tag}) is available. "
                     "Visit https://github.com/dhis2/tool-dq-workbench/releases to update."

--- a/docs/superpowers/plans/2026-03-18-version-update-notification.md
+++ b/docs/superpowers/plans/2026-03-18-version-update-notification.md
@@ -1,0 +1,148 @@
+# Version Update Notification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a one-time flash notification on the first page load after startup when a newer version of DQ Workbench is available on GitHub.
+
+**Architecture:** Add a module-level `_available_update` variable to `app/web/app.py`. The existing `_check_for_updates()` background thread writes the latest version tag to it when a newer version is found. A `before_request` hook registered in `create_app()` reads the variable, flashes a message with a link to the releases page, and clears the variable — so the message appears exactly once per process lifetime.
+
+**Tech Stack:** Python, Flask (`flash`, `before_request`), `markupsafe.Markup` (Flask dependency, for HTML-safe flash content)
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `app/web/app.py` | Add `_available_update` module var; write to it in `_check_for_updates()`; register `before_request` hook in `create_app()` |
+| `tests/test_web_index.py` | Add two tests: flash appears on first load, does not appear on second load |
+
+---
+
+### Task 1: Surface version update as a one-time flash notification
+
+**Files:**
+- Modify: `app/web/app.py`
+- Test: `tests/test_web_index.py`
+
+Everything lives in one task because the observable behavior (flash on first request, not on second) requires both the storage variable and the hook to be in place before any test can pass.
+
+- [ ] **Step 1: Write the two failing tests**
+
+Add to `tests/test_web_index.py`, after the existing imports (the file already imports `pytest`, `yaml`, `os`, and `from app.web.app import create_app`):
+
+```python
+def test_update_notification_shown_on_first_request(client_blank):
+    """If a newer version is available, flash message appears on first page load."""
+    import app.web.app as app_module
+    app_module._available_update = "9.9.9"
+    try:
+        response = client_blank.get('/', follow_redirects=True)
+        assert b'9.9.9' in response.data
+        assert b'github.com/dhis2/tool-dq-workbench/releases' in response.data
+    finally:
+        app_module._available_update = None
+
+
+def test_update_notification_shown_only_once(client_blank):
+    """Update flash message must not appear on the second request."""
+    import app.web.app as app_module
+    app_module._available_update = "9.9.9"
+    try:
+        client_blank.get('/', follow_redirects=True)   # first request consumes it
+        response = client_blank.get('/', follow_redirects=True)  # second request
+        assert b'9.9.9' not in response.data
+    finally:
+        app_module._available_update = None
+```
+
+Note: `client_blank` fixture already exists in the file — it creates a test Flask app with a blank config. The `follow_redirects=True` is needed because `GET /` with a blank config redirects to `/api/edit-server`, and the flash is rendered on the redirected page.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_web_index.py::test_update_notification_shown_on_first_request tests/test_web_index.py::test_update_notification_shown_only_once -v
+```
+
+Expected: both FAIL — `_available_update` attribute does not exist yet.
+
+- [ ] **Step 3: Add the module-level variable**
+
+At the top of `app/web/app.py`, after the existing imports and before any function definitions, add:
+
+```python
+_available_update: str | None = None  # set by _check_for_updates(); read once by before_request hook
+```
+
+- [ ] **Step 4: Write to it from `_check_for_updates()`**
+
+Inside `_check_for_updates()`, the nested `_do_check()` function ends with this block:
+
+```python
+            if _parse(latest_tag) > _parse(current):
+                logging.warning(
+                    f"A newer version (v{latest_tag}) is available. "
+                    "Visit https://github.com/dhis2/tool-dq-workbench/releases to update."
+                )
+```
+
+Replace the **entire `if _parse(latest_tag) > _parse(current):` block** with:
+
+```python
+            if _parse(latest_tag) > _parse(current):
+                global _available_update
+                _available_update = latest_tag
+                logging.warning(
+                    f"A newer version (v{latest_tag}) is available. "
+                    "Visit https://github.com/dhis2/tool-dq-workbench/releases to update."
+                )
+```
+
+`global _available_update` inside the nested `_do_check` correctly refers to the module-level variable (Python's `global` always means module scope, regardless of nesting depth). Keep the existing `logging.warning` — it's useful for server logs.
+
+- [ ] **Step 5: Register the `before_request` hook in `create_app()`**
+
+In `create_app()`, after `register_routes(app)` and before `return app`, add:
+
+```python
+    from markupsafe import Markup  # preferred over flask.Markup, which was deprecated in Flask 2.0
+
+    @app.before_request
+    def _notify_if_update_available():
+        global _available_update
+        if _available_update:
+            flash(
+                Markup(
+                    f"A newer version (v{_available_update}) is available. "
+                    '<a href="https://github.com/dhis2/tool-dq-workbench/releases" '
+                    'class="alert-link" target="_blank" rel="noopener">Download it here.</a>'
+                ),
+                'info',
+            )
+            _available_update = None
+```
+
+`markupsafe` is a direct Flask dependency and is always available. `Markup` marks the string as HTML-safe so Jinja2 does not escape the `<a>` tag. `flash` is already imported at the top of `app.py`.
+
+- [ ] **Step 6: Run the two new tests**
+
+```bash
+pytest tests/test_web_index.py::test_update_notification_shown_on_first_request tests/test_web_index.py::test_update_notification_shown_only_once -v
+```
+
+Expected: both PASS.
+
+- [ ] **Step 7: Run the full test suite to check for regressions**
+
+```bash
+pytest tests/test_web_index.py -v
+```
+
+Expected: all 8 tests pass (6 existing + 2 new).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/web/app.py tests/test_web_index.py
+git commit -m "feat: show one-time flash notification when newer version is available"
+```

--- a/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
+++ b/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
@@ -30,10 +30,10 @@ Register a `before_request` hook inside `create_app()`. On the first request aft
 
 The hook must declare `global _available_update` before assigning `None`; without it Python treats the assignment as a local variable and the message flashes on every request:
 
-Flask auto-escapes flash message strings, so use `flask.Markup` to include a safe clickable link:
+Flask auto-escapes flash message strings, so use `markupsafe.Markup` to include a safe clickable link (`flask.Markup` was deprecated in Flask 2.0; `markupsafe` is a direct Flask dependency):
 
 ```python
-from flask import Markup
+from markupsafe import Markup
 
 @app.before_request
 def _notify_if_update_available():

--- a/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
+++ b/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
@@ -30,14 +30,21 @@ Register a `before_request` hook inside `create_app()`. On the first request aft
 
 The hook must declare `global _available_update` before assigning `None`; without it Python treats the assignment as a local variable and the message flashes on every request:
 
+Flask auto-escapes flash message strings, so use `flask.Markup` to include a safe clickable link:
+
 ```python
+from flask import Markup
+
 @app.before_request
 def _notify_if_update_available():
     global _available_update
     if _available_update:
         flash(
-            f"A newer version (v{_available_update}) is available. "
-            "Visit the releases page to update.",
+            Markup(
+                f"A newer version (v{_available_update}) is available. "
+                '<a href="https://github.com/dhis2/tool-dq-workbench/releases" '
+                'class="alert-link" target="_blank" rel="noopener">Download it here.</a>'
+            ),
             'info',
         )
         _available_update = None

--- a/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
+++ b/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
@@ -28,6 +28,21 @@ Register a `before_request` hook inside `create_app()`. On the first request aft
    `"A newer version (v0.9.12) is available. Visit the releases page to update."`
 2. Sets `_available_update = None` so the hook is effectively a no-op on every subsequent request.
 
+The hook must declare `global _available_update` before assigning `None`; without it Python treats the assignment as a local variable and the message flashes on every request:
+
+```python
+@app.before_request
+def _notify_if_update_available():
+    global _available_update
+    if _available_update:
+        flash(
+            f"A newer version (v{_available_update}) is available. "
+            "Visit the releases page to update.",
+            'info',
+        )
+        _available_update = None
+```
+
 ### Display
 
 No template changes required. `layout.html` already includes `partials/_flashes.html`, which renders all flash messages on every page. The `info` category maps to Bootstrap `alert-info` (blue), consistent with the config path banner added to `edit_server.html`.

--- a/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
+++ b/docs/superpowers/specs/2026-03-18-version-update-notification-design.md
@@ -1,0 +1,55 @@
+# Version Update Notification — Design Spec
+
+## Goal
+
+Inform users that a newer version of DQ Workbench is available, displayed once on the first page they open after starting the app, then gone.
+
+## Context
+
+`_check_for_updates()` in `app/web/app.py` already runs once in a background thread on startup and compares the installed version against the latest GitHub release. Currently it only logs a warning. This spec covers surfacing that result in the web UI.
+
+## Design
+
+### Storage
+
+Add a module-level variable in `app/web/app.py`:
+
+```python
+_available_update: str | None = None  # set by _check_for_updates(); read once by before_request hook
+```
+
+`_check_for_updates()` writes the latest tag string (e.g. `"0.9.12"`) to `_available_update` when a newer version is found. No other change to the existing check logic.
+
+### Surfacing
+
+Register a `before_request` hook inside `create_app()`. On the first request after startup, if `_available_update` is set, the hook:
+
+1. Calls `flash()` with an `info` category and a message of the form:
+   `"A newer version (v0.9.12) is available. Visit the releases page to update."`
+2. Sets `_available_update = None` so the hook is effectively a no-op on every subsequent request.
+
+### Display
+
+No template changes required. `layout.html` already includes `partials/_flashes.html`, which renders all flash messages on every page. The `info` category maps to Bootstrap `alert-info` (blue), consistent with the config path banner added to `edit_server.html`.
+
+The message appears on whatever page the user first loads in the browser and disappears after that render. Dismissal is inherent to Flask's flash system — messages are consumed on read.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `app/web/app.py` | Add `_available_update` module var; update `_check_for_updates()` to write to it; register `before_request` hook in `create_app()` |
+
+No other files change.
+
+## Out of Scope
+
+- Persistent dismissal across restarts (not needed — check only runs once per startup anyway)
+- Dashboard or other page-specific placement (server config page is sufficient)
+- Continuous background polling (startup-only check is already in place)
+
+## Testing
+
+- Unit test: mock `_available_update` set to a version string; GET any page; assert flash message appears in response and contains the version string.
+- Unit test: same setup; GET a second page; assert flash message does NOT appear (consumed on first render).
+- Existing tests must continue to pass (the hook is a no-op when `_available_update` is None).

--- a/tests/test_web_index.py
+++ b/tests/test_web_index.py
@@ -105,3 +105,27 @@ def test_edit_server_shows_config_path(client_blank, blank_config):
     """GET /api/edit-server must display the absolute config file path."""
     response = client_blank.get('/api/edit-server')
     assert os.path.abspath(blank_config).encode() in response.data
+
+
+def test_update_notification_shown_on_first_request(client_blank):
+    """If a newer version is available, flash message appears on first page load."""
+    import app.web.app as app_module
+    app_module._available_update = "9.9.9"
+    try:
+        response = client_blank.get('/', follow_redirects=True)
+        assert b'9.9.9' in response.data
+        assert b'github.com/dhis2/tool-dq-workbench/releases' in response.data
+    finally:
+        app_module._available_update = None
+
+
+def test_update_notification_shown_only_once(client_blank):
+    """Update flash message must not appear on the second request."""
+    import app.web.app as app_module
+    app_module._available_update = "9.9.9"
+    try:
+        client_blank.get('/', follow_redirects=True)   # first request consumes it
+        response = client_blank.get('/', follow_redirects=True)  # second request
+        assert b'9.9.9' not in response.data
+    finally:
+        app_module._available_update = None


### PR DESCRIPTION
## Summary

- Surfaces the existing startup version check in the web UI as a one-time flash notification
- On first page load after startup, users see an info banner: "A newer version (vX.Y.Z) is available. Download it here." with a link to the GitHub releases page
- Banner appears once and is gone — Flask's flash system consumes it on render

## Test Plan

- [ ] Start the app with a newer version available (mock `_available_update` or trigger manually) — confirm the blue info banner appears on the first page loaded
- [ ] Reload the page — confirm the banner does not appear again
- [ ] All 8 tests in `tests/test_web_index.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)